### PR TITLE
Bug fixes for user id handling and board settings parsing

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -23,4 +23,5 @@ node api-test.js
 TEST_EXIT_CODE=$?
 
 echo "Tests completed with exit code: $TEST_EXIT_CODE"
-exit $TEST_EXIT_CODE 
+exit $TEST_EXIT_CODE
+

--- a/src/private/middleware/rateLimiter.js
+++ b/src/private/middleware/rateLimiter.js
@@ -261,7 +261,7 @@ class RateLimiter {
                 '0.0.0.0';
       
       // Use user ID if authenticated
-      const userId = req.user?.id;
+      const userId = req.user?.user_id || req.user?.id;
       
       // If user is authenticated, include user ID in the key
       const identifier = userId ? `${userId}:${ip}` : ip;

--- a/src/private/models/boardModel.js
+++ b/src/private/models/boardModel.js
@@ -7,6 +7,7 @@ const configLoader = require('../utils/configLoader');
 const DatabaseHelpers = require('../utils/databaseHelpers');
 const { createValidator } = require('../middleware/validation');
 const globalCache = require('../utils/globalCache');
+const BoardFormatterService = require('../services/boardFormatterService');
 
 class BoardModel {
   constructor() {
@@ -1146,29 +1147,13 @@ class BoardModel {
    * @returns {Object} - Parsed settings
    */
   _parseSettings(settings) {
-    if (!settings) {
-      return {
-        size: this.defaultBoardSize,
-        freeSpace: true
-      };
-    }
-    
-    try {
-      const parsedSettings = JSON.parse(settings);
-      return {
-        size: this.validateBoardSize(parsedSettings.size || this.defaultBoardSize),
-        freeSpace: parsedSettings.freeSpace !== false
-      };
-    } catch (e) {
-      logger.error('Failed to parse board settings', {
-        error: e.message,
-        settings
-      });
-      return {
-        size: this.defaultBoardSize,
-        freeSpace: true
-      };
-    }
+    // Delegate parsing to BoardFormatterService for consistency
+    const parsed = BoardFormatterService.parseSettings(settings);
+
+    // Ensure size respects model limits
+    parsed.size = this.validateBoardSize(parsed.size);
+
+    return parsed;
   }
 
   /**

--- a/src/private/routes/admin/users.js
+++ b/src/private/routes/admin/users.js
@@ -59,13 +59,13 @@ router.post('/approve/:userId', asyncHandler(async (req, res) => {
     // Log the approval action
   logger.admin.info('User approved by admin', {
       userId,
-      adminId: req.user.id,
+      adminId: req.user.user_id || req.user.id,
       adminUsername: req.user.username
     });
     
     // Add notification about the approval to the admin's list
     await notificationModel.createNotification({
-      userId: req.user.id,
+      userId: req.user.user_id || req.user.id,
       message: `You approved user ID ${userId}`,
       type: 'admin_action',
       data: {
@@ -97,13 +97,13 @@ router.post('/reject/:userId', asyncHandler(async (req, res) => {
     // Log the rejection action
   logger.admin.info('User rejected by admin', {
       userId,
-      adminId: req.user.id,
+      adminId: req.user.user_id || req.user.id,
       adminUsername: req.user.username
     });
     
     // Add notification about the rejection to the admin's list
     await notificationModel.createNotification({
-      userId: req.user.id,
+      userId: req.user.user_id || req.user.id,
       message: `You rejected user ID ${userId}`,
       type: 'admin_action',
       data: {
@@ -230,14 +230,14 @@ router.post('/:userId/make-admin', async (req, res) => {
       type: 'admin_status',
       data: {
         grantedBy: req.user.username,
-        grantedById: req.user.id
+        grantedById: req.user.user_id || req.user.id
       }
     });
     
     // Log the action
     logger.info('User promoted to admin', {
       userId,
-      adminId: req.user.id,
+      adminId: req.user.user_id || req.user.id,
       adminUsername: req.user.username
     });
     
@@ -265,7 +265,7 @@ router.post('/:userId/remove-admin', async (req, res) => {
     }
     
     // Check if trying to remove own admin privileges
-    if (userId === req.user.id.toString()) {
+    if (userId === (req.user.user_id || req.user.id).toString()) {
       return res.status(400).json({ error: 'Cannot remove your own admin privileges' });
     }
     
@@ -287,14 +287,14 @@ router.post('/:userId/remove-admin', async (req, res) => {
       type: 'admin_status',
       data: {
         removedBy: req.user.username,
-        removedById: req.user.id
+        removedById: req.user.user_id || req.user.id
       }
     });
     
     // Log the action
     logger.info('Admin privileges removed from user', {
       userId,
-      adminId: req.user.id,
+      adminId: req.user.user_id || req.user.id,
       adminUsername: req.user.username
     });
     

--- a/src/private/routes/users.js
+++ b/src/private/routes/users.js
@@ -56,7 +56,7 @@ router.put('/profile', asyncHandler(async (req, res) => {
 
 // Get user's boards
 router.get('/boards', asyncHandler(async (req, res) => {
-    const userId = req.user.id;
+    const userId = req.user.user_id || req.user.id;
     const options = {
       userId,
       includePublic: false


### PR DESCRIPTION
## Summary
- normalize user id access across routes and middleware
- reuse BoardFormatterService for board settings parsing
- include user_id fallback in rate limiter
- simplify API tests and fix run-tests script

## Testing
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d10e4bae883209a801e9aeb601bf7